### PR TITLE
Fixed initialisation order of subscribers and error handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .gradle/
 build/
 gradle.properties
+*.iml
+.idea/

--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -715,8 +715,8 @@ public interface EventStream<T> {
         return new LazilyBoundStream<Try<T>>() {
             @Override
             protected Subscription subscribeToInputs() {
-                Subscription s1 = EventStream.this.subscribe(t -> emit(Try.success(t)));
                 Subscription s2 = EventStream.this.monitor(er -> emit(Try.failure(er)));
+                Subscription s1 = EventStream.this.subscribe(t -> emit(Try.success(t)));
                 return s1.and(s2);
             }
         };
@@ -734,8 +734,8 @@ public interface EventStream<T> {
         return new LazilyBoundStream<T>() {
             @Override
             protected Subscription subscribeToInputs() {
-                Subscription s1 = EventStream.this.subscribe(this::emit);
                 Subscription s2 = EventStream.this.monitor(handler);
+                Subscription s1 = EventStream.this.subscribe(this::emit);
                 return s1.and(s2);
             }
         };

--- a/reactfx/src/main/java/org/reactfx/EventStreamBase.java
+++ b/reactfx/src/main/java/org/reactfx/EventStreamBase.java
@@ -117,10 +117,10 @@ public abstract class EventStreamBase<S> {
 
     public final Subscription subscribe(S subscriber) {
         subscribers = ListHelper.add(subscribers, subscriber);
-        newSubscriber(subscriber);
         if(ListHelper.size(subscribers) == 1) {
             firstSubscriber();
         }
+        newSubscriber(subscriber);
         return () -> unsubscribe(subscriber);
     }
 

--- a/reactfx/src/test/java/org/reactfx/EventStreamsTest.java
+++ b/reactfx/src/test/java/org/reactfx/EventStreamsTest.java
@@ -1,0 +1,40 @@
+package org.reactfx;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.reactfx.inhibeans.property.SimpleIntegerProperty;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public class EventStreamsTest {
+    /**
+     * Stream of property values should work normally even first value in stream (property
+     * value on the moment of subscription) produces exception. The catch is first value produced in
+     * the very moment of establishing subsription so order of initialization matters.
+     */
+    @Test
+    public void property_values_stream_with_faulty_first_value_test() {
+        SimpleIntegerProperty intProperty = new SimpleIntegerProperty(-1);
+        List<String> emitted = new LinkedList<>();
+        List<Throwable> errors = new LinkedList<>();
+
+        EventStreams.valuesOf(intProperty)
+                .map(i -> {
+                    if (i.intValue() < 0) {
+                        throw new IllegalArgumentException("Accepting only positive numbers");
+                    }
+                    return String.valueOf(i);
+                })
+                .handleErrors(errors::add)
+                .subscribe(emitted::add);
+
+        intProperty.set(10);
+        intProperty.set(-2);
+        intProperty.set(0);
+
+        assertEquals(Arrays.asList("10", "0"), emitted);
+        assertEquals(2, errors.size());
+    }
+}


### PR DESCRIPTION
Hi!
Tried to use your reactive library in my GUI project and stumbled upon scenario which produce inconsistent stream behaviour. For example this code produces an empty stream:

```
    SimpleIntegerProperty intProperty = new SimpleIntegerProperty(-1);
    List<String> emitted = new LinkedList<>();
    List<Throwable> errors = new LinkedList<>();

    EventStreams.valuesOf(intProperty)
            .map(i -> {
                if (i.intValue() < 0) {
                    throw new IllegalArgumentException("Accepting only positive numbers");
                }
                return String.valueOf(i);
            })
            .handleErrors(errors::add)
            .subscribe(emitted::add);
```

The problem is lazy subscription mechanism plus property observer generate first event before stream pipe is properly initialised. My changes fixing this problem.
