### PR TITLE
live concatination of two observable lists

### DIFF
--- a/reactfx/src/main/java/org/reactfx/collection/EmptyLiveList.java
+++ b/reactfx/src/main/java/org/reactfx/collection/EmptyLiveList.java
@@ -1,0 +1,38 @@
+package org.reactfx.collection;
+
+public class EmptyLiveList<E>
+implements LiveList<E>, ReadOnlyLiveListImpl<E> {
+
+    private static final EmptyLiveList<Object> INSTANCE = new EmptyLiveList<>();
+
+    @SuppressWarnings("unchecked")
+    public static <E> LiveList<E> getInstance() {
+        return (LiveList<E>) INSTANCE;
+    }
+
+    public EmptyLiveList() {
+    }
+
+    @Override
+    public void addObserver(
+        Observer<? super E, ?> observer) {
+        // no-op
+    }
+
+    @Override
+    public void removeObserver(
+        Observer<? super E, ?> observer) {
+        // no-op
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public E get(
+        int index) {
+        throw new IndexOutOfBoundsException("Index: " + index);
+    }
+}

--- a/reactfx/src/main/java/org/reactfx/collection/LiveConcatenation.java
+++ b/reactfx/src/main/java/org/reactfx/collection/LiveConcatenation.java
@@ -1,0 +1,97 @@
+package org.reactfx.collection;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javafx.collections.ObservableList;
+
+import org.reactfx.Subscription;
+import org.reactfx.util.Lists;
+
+public class LiveConcatenation<E>
+extends LiveListBase<E>
+implements ReadOnlyLiveListImpl<E> {
+
+    private final ObservableList<? extends E> left;
+
+    private final ObservableList<? extends E> right;
+
+    public LiveConcatenation(
+        ObservableList<? extends E> left,
+        ObservableList<? extends E> right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("unchecked")
+    public static <E> LiveList<E> multi(
+        ObservableList<? extends E>... inputs) {
+        switch (inputs.length) {
+            case 0:
+                return EmptyLiveList.getInstance();
+            case 1:
+                return new LiveListWrapper<>(inputs[0]);
+            case 2:
+                return new LiveConcatenation<>(inputs[0], inputs[1]);
+            case 3:
+                return new LiveConcatenation<>(
+                    new LiveConcatenation<>(inputs[0], inputs[1]),
+                    inputs[2]
+                );
+            default:
+                return multi(
+                    new LiveConcatenation<>(inputs[0], inputs[1]),
+                    multi(Arrays.stream(inputs).skip(2).toArray(ObservableList[]::new))
+                );
+        }
+    }
+
+    @Override
+    protected Subscription observeInputs() {
+        return Subscription.multi(
+            LiveList.observeQuasiChanges(left, this::notifyObservers),
+            LiveList.observeQuasiChanges(
+                right,
+                change -> notifyObservers(change, left.size())
+            )
+        );
+    }
+
+    private void notifyObservers(
+        QuasiListChange<? extends E> change,
+        int offset) {
+        notifyObservers(() -> Lists.mappedView(change.getModifications(),
+            mod -> new QuasiListModification<E>() {
+                @Override
+                public int getFrom() {
+                    return mod.getFrom() + offset;
+                }
+
+                @Override
+                public int getAddedSize() {
+                    return mod.getAddedSize();
+                }
+
+                @Override
+                public List<? extends E> getRemoved() {
+                    return mod.getRemoved();
+                }
+            }
+        ));
+    }
+
+    @Override
+    public int size() {
+        return left.size() + right.size();
+    }
+
+    @Override
+    public E get(
+        int index) {
+        int offset = left.size();
+        return index < offset
+            ? left.get(index)
+            : right.get(index - offset);
+    }
+}

--- a/reactfx/src/main/java/org/reactfx/collection/LiveListWrapper.java
+++ b/reactfx/src/main/java/org/reactfx/collection/LiveListWrapper.java
@@ -1,0 +1,32 @@
+package org.reactfx.collection;
+
+import javafx.collections.ObservableList;
+import org.reactfx.Subscription;
+
+public class LiveListWrapper<E>
+extends LiveListBase<E>
+implements ReadOnlyLiveListImpl<E> {
+
+    private final ObservableList<? extends E> delegate;
+
+    public LiveListWrapper(
+        ObservableList<? extends E> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    protected Subscription observeInputs() {
+        return LiveList.observeQuasiChanges(delegate, this::notifyObservers);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public E get(
+        int index) {
+        return delegate.get(index);
+    }
+}

--- a/reactfx/src/test/java/org/reactfx/collection/LiveConcatenationTest.java
+++ b/reactfx/src/test/java/org/reactfx/collection/LiveConcatenationTest.java
@@ -1,0 +1,110 @@
+package org.reactfx.collection;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class LiveConcatenationTest {
+
+    private LiveArrayList<String> left;
+    private LiveArrayList<String> right;
+    private LiveConcatenation<String> concat;
+
+    @Before
+    public void setUp() {
+        left = new LiveArrayList<>("1", "2");
+        right = new LiveArrayList<>("one", "two");
+        concat = new LiveConcatenation<>(left, right);
+    }
+
+    @Test
+    public void testValues() {
+        Assert.assertEquals(4, concat.size());
+        Assert.assertEquals(Arrays.asList("1", "2", "one", "two"), concat);
+    }
+
+    @Test
+    public void testAddLeft() {
+        concat.observeChanges(change -> {
+            Assert.assertEquals(1, change.getModificationCount());
+            ListModification<? extends String> mod = change.getModifications().get(0);
+            Assert.assertEquals(Collections.singletonList("3"), mod.getAddedSubList());
+            Assert.assertTrue(mod.getRemoved().isEmpty());
+            Assert.assertEquals(2, mod.getFrom());
+        });
+
+        left.add("3");
+        Assert.assertEquals(
+            Arrays.asList("1", "2", "3", "one", "two"),
+            concat
+        );
+    }
+
+    @Test
+    public void testRemoveLeft() {
+        concat.observeChanges(change -> {
+            Assert.assertEquals(1, change.getModificationCount());
+            ListModification<? extends String> mod = change.getModifications().get(0);
+            Assert.assertEquals(Collections.singletonList("1"), mod.getRemoved());
+            Assert.assertTrue(mod.getAddedSubList().isEmpty());
+            Assert.assertEquals(0, mod.getFrom());
+        });
+
+        left.remove("1");
+        Assert.assertEquals(
+            Arrays.asList("2", "one", "two"),
+            concat
+        );
+    }
+
+    @Test
+    public void testAddRight() {
+        concat.observeChanges(change -> {
+            Assert.assertEquals(1, change.getModificationCount());
+            ListModification<? extends String> mod = change.getModifications().get(0);
+            Assert.assertEquals(Collections.singletonList("zero"), mod.getAddedSubList());
+            Assert.assertTrue(mod.getRemoved().isEmpty());
+            Assert.assertEquals(2, mod.getFrom());
+        });
+
+        right.add(0, "zero");
+        Assert.assertEquals(
+            Arrays.asList("1", "2", "zero", "one", "two"),
+            concat
+        );
+    }
+
+    @Test
+    public void testRemoveRight() {
+        concat.observeChanges(change -> {
+            Assert.assertEquals(1, change.getModificationCount());
+            ListModification<? extends String> mod = change.getModifications().get(0);
+            Assert.assertEquals(Collections.singletonList("two"), mod.getRemoved());
+            Assert.assertTrue(mod.getAddedSubList().isEmpty());
+            Assert.assertEquals(3, mod.getFrom());
+        });
+
+        right.remove(1);
+        Assert.assertEquals(
+            Arrays.asList("1", "2", "one"),
+            concat
+        );
+    }
+
+    @Test
+    public void testMulti() {
+        Assert.assertEquals(
+            Arrays.asList("0", "1", "2", "3", "4", "5"),
+            LiveConcatenation.multi(
+                new LiveArrayList<>("0"),
+                new LiveArrayList<>("1", "2"),
+                new LiveArrayList<>("3"),
+                new LiveArrayList<>("4"),
+                new LiveArrayList<>("5")
+            )
+        );
+    }
+}


### PR DESCRIPTION
I have tried to implement a concatenation of two observable lists.

What do you think about the method `LiveConcatenation.multi(...)`? Is it OK? Or should it be dropped out with classes EmptyLiveList and LiveListWrapper?

Is LiveConcatenation a proper class name?

How can we extend API of LiveList class?
* Factory method `LiveList.concat(list1, list2)`.
* Methods `append(list)` and `prepend(list)`.

Could you add anything else?
