### PR TITLE
Add method for Val changes.

### DIFF
--- a/reactfx/src/main/java/org/reactfx/value/Val.java
+++ b/reactfx/src/main/java/org/reactfx/value/Val.java
@@ -19,6 +19,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
+import org.reactfx.Change;
 import org.reactfx.EventStream;
 import org.reactfx.EventStreamBase;
 import org.reactfx.EventStreams;
@@ -103,6 +104,14 @@ extends ObservableValue<T>, Observable<Consumer<? super T>> {
                 return observeInvalidations(this::emit);
             }
         };
+    }
+
+    /**
+     * Returns a stream of changed values, which emits the changed value
+     * (i.e. the old and the new value) on each change of this observable value.
+     */
+    default EventStream<Change<T>> changes() {
+        return EventStreams.changesOf(this);
     }
 
     /**

--- a/reactfx/src/test/java/org/reactfx/value/ValTest.java
+++ b/reactfx/src/test/java/org/reactfx/value/ValTest.java
@@ -1,0 +1,34 @@
+package org.reactfx.value;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+
+import org.junit.Test;
+import org.reactfx.Change;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ValTest {
+
+    @Test
+    public void changesTest() {
+        IntegerProperty src = new SimpleIntegerProperty(0);
+        Val<Number> val = Val.wrap(src);
+
+        List<Change<Number>> changes = new ArrayList<>();
+        val.changes().subscribe(changes::add);
+
+        src.set(1);
+        src.set(2);
+        src.set(3);
+
+        assertArrayEquals(Arrays.asList(0, 1, 2).toArray(),
+            changes.stream().map(change -> change.getOldValue()).toArray());
+        assertArrayEquals(Arrays.asList(1, 2, 3).toArray(),
+            changes.stream().map(change -> change.getNewValue()).toArray());
+    }
+
+}


### PR DESCRIPTION
Code and tests that adds `Val#changes()`. This aligns some methods in `Val` to the static methods provided by `EventStreams`. So that `invalidations()`, `changes()` and `values()` provide a better version of the `ObservableValue` concept.

~~~java
// static methods in EventStreams.
ObservableValue<T> observable = ...;
EventStream<?> invalidations = EventStreams.invalidationsOf(observable);
EventStream<Change<T>> changes = EventStreams.changesOf(observable);
EventStream<T> values = EventStreams.valuesOf(observable);

// similar methods in Val (and Var).
Val<T> val = Val.wrap(observable);
EventStream<?> invalidations = val.invalidations();
EventStream<Change<T>> changes = val.changes();
EventStream<T> values = val.values();
~~~

(I based this branch on my other PR. Hope this prevents merge conflicts. Will rebase this if needed.)
