### PR TITLE
Val.combine(a, b, c, f) dependency is fixed.

### DIFF
--- a/reactfx/src/main/java/org/reactfx/value/Val.java
+++ b/reactfx/src/main/java/org/reactfx/value/Val.java
@@ -604,7 +604,7 @@ extends ObservableValue<T>, Observable<Consumer<? super T>> {
                         return null;
                     }
                 },
-                src1, src3, src3);
+                src1, src2, src3);
     }
 
     static <A, B, C, D, R> Val<R> combine(


### PR DESCRIPTION
Dependency of  Val.combine(a, b, c, f) from second argument was broken.