### PR TITLE
Added prepend EventStream

### DIFF
--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -110,6 +110,37 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
     }
 
     /**
+     * Returns an event stream that emits an initial event when something
+     * subscribes to it and it has no event to emit. Useful when this
+     * stream will only emit a event when an JavaFX {@code InputEvent}
+     * occurs and it is being combined with other EventStreams whose
+     * combined EventStream needs to work immediately upon program start.
+     * <pre>
+     * {@code
+     * EventStream<Boolean> controlPresses = EventStreams
+     *     .eventsOf(scene, KeyEvent.KEY_PRESSED)
+     *     .filter(key -> key.getCode().is(KeyCode.CONTROL))
+     *     .map(key -> key.isControlDown());
+     *
+     * EventSource<?> other;
+     * EventStream<Tuple2<Boolean, ?>> combo = EventStreams.combine(controlPresses, other);
+     *
+     * // This will not run until user presses the control key at least once.
+     * combo.subscribe(tuple2 -> System.out.println("Combo emitted an event."));
+     *
+     * EventStream<Boolean> controlDown = controlPresses.prepend(false);
+     * EventStream<Tuple2<Boolean, ?>> betterCombo = EventStreams.combine(controlDown, other);
+     * betterCombo.subscribe(tuple2 -> System.out.println("Better Combo emitted an event immediately upon program start."));
+     * }
+     * </pre>
+     *
+     * @param initial the event this event stream will emit if something subscribes to this stream and this stream does not have an event.
+     */
+    default EventStream<T> prepend(T initial) {
+        return new PrependEventStream<>(this, initial);
+    }
+
+    /**
      * Returns an event stream that emits the same<sup>(*)</sup> events as this
      * stream, but <em>before</em> emitting each event performs the given side
      * effect. This is useful for debugging. The side effect is not allowed to

--- a/reactfx/src/main/java/org/reactfx/PrependEventStream.java
+++ b/reactfx/src/main/java/org/reactfx/PrependEventStream.java
@@ -1,0 +1,27 @@
+package org.reactfx;
+
+public class PrependEventStream<T> extends EventStreamBase<T> {
+    private final EventStream<T> input;
+    private final T initial;
+
+    private boolean hasEvent = false;
+    private T event = null;
+
+    public PrependEventStream(
+            EventStream<T> input,
+            T initial) {
+        this.input = input;
+        this.initial = initial;
+    }
+
+    @Override
+    protected final Subscription observeInputs() {
+        return input.subscribe(e -> {
+            event = hasEvent
+                    ? e
+                    : initial;
+            hasEvent = true;
+            emit(event);
+        });
+    }
+}

--- a/reactfx/src/test/java/org/reactfx/PrependEventStreamTest.java
+++ b/reactfx/src/test/java/org/reactfx/PrependEventStreamTest.java
@@ -33,16 +33,7 @@ public class PrependEventStreamTest {
                     .prepend(false);
             controlPressed.subscribe(counter::accept);
 
-            // simulate a control key being pressed
-            KeyEvent event = new KeyEvent(
-                    rectangle, rectangle, KeyEvent.KEY_PRESSED,
-                    "", "", KeyCode.CONTROL,
-                    // shift, control, alt, meta
-                    false, true, false, false
-            );
-            Event.fireEvent(rectangle, event);
-
-            assertEquals(2, counter.get());
+            assertEquals(1, counter.get());
         });
     }
 }

--- a/reactfx/src/test/java/org/reactfx/PrependEventStreamTest.java
+++ b/reactfx/src/test/java/org/reactfx/PrependEventStreamTest.java
@@ -1,0 +1,48 @@
+package org.reactfx;
+
+import static org.junit.Assert.*;
+
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.event.Event;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.shape.Rectangle;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by jordan on 11/23/15.
+ */
+public class PrependEventStreamTest {
+
+    @Before
+    public void setUp() {
+        new JFXPanel();
+    }
+
+    @Test
+    public void test() {
+        Platform.runLater(() -> {
+            EventCounter counter = new EventCounter();
+            final Rectangle rectangle = new Rectangle();
+            EventStream<Boolean> controlPressed = EventStreams
+                    .eventsOf(rectangle, KeyEvent.KEY_PRESSED)
+                    .filter(key -> key.getCode().equals(KeyCode.CONTROL))
+                    .map(KeyEvent::isControlDown)
+                    .prepend(false);
+            controlPressed.subscribe(counter::accept);
+
+            // simulate a control key being pressed
+            KeyEvent event = new KeyEvent(
+                    rectangle, rectangle, KeyEvent.KEY_PRESSED,
+                    "", "", KeyCode.CONTROL,
+                    // shift, control, alt, meta
+                    false, true, false, false
+            );
+            Event.fireEvent(rectangle, event);
+
+            assertEquals(2, counter.get());
+        });
+    }
+}


### PR DESCRIPTION
I hope I've implemented the PrependEventStream correclty. I wasn't sure if it should be:
````java
return input.subscribe(e -> {
    event = hasEvent
            ? e
            : initial;
    hasEvent = true;
    emit(event);
});
````
or
````java
return input.subscribe(e -> {
    event = e != null
            ? e
            : initial;
    emit(event);
});
````

Both work, but I wasn't sure what the finer implications of one would be over the other in cases beyond the `controlPressed` case that initially made us think of writing this one.