### PR TITLE
Val.lazy() and Val.lazyAsync()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gradle.properties
 .classpath
 .project
 .settings/
+.idea/

--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -27,13 +27,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
 
-import org.reactfx.util.AccumulatorSize;
-import org.reactfx.util.Either;
-import org.reactfx.util.Experimental;
-import org.reactfx.util.FxTimer;
-import org.reactfx.util.NotificationAccumulator;
-import org.reactfx.util.Timer;
-import org.reactfx.util.Tuple2;
+import org.reactfx.util.*;
 import org.reactfx.value.Val;
 
 /**

--- a/reactfx/src/main/java/org/reactfx/EventStreams.java
+++ b/reactfx/src/main/java/org/reactfx/EventStreams.java
@@ -31,14 +31,7 @@ import javafx.stage.Window;
 
 import org.reactfx.collection.ListModification;
 import org.reactfx.collection.LiveList;
-import org.reactfx.util.Either;
-import org.reactfx.util.FxTimer;
-import org.reactfx.util.Timer;
-import org.reactfx.util.Tuple2;
-import org.reactfx.util.Tuple3;
-import org.reactfx.util.Tuple4;
-import org.reactfx.util.Tuple5;
-import org.reactfx.util.Tuple6;
+import org.reactfx.util.*;
 
 public class EventStreams {
 

--- a/reactfx/src/main/java/org/reactfx/util/ScheduledExecutorServiceTimer.java
+++ b/reactfx/src/main/java/org/reactfx/util/ScheduledExecutorServiceTimer.java
@@ -1,14 +1,11 @@
-package org.reactfx;
+package org.reactfx.util;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.reactfx.util.Timer;
-import org.reactfx.util.TriFunction;
-
-class ScheduledExecutorServiceTimer implements Timer {
+public class ScheduledExecutorServiceTimer implements Timer {
 
     public static Timer create(
             java.time.Duration timeout,

--- a/reactfx/src/main/java/org/reactfx/value/RigidVal.java
+++ b/reactfx/src/main/java/org/reactfx/value/RigidVal.java
@@ -1,0 +1,13 @@
+
+package org.reactfx.value;
+
+
+import java.util.function.Consumer;
+
+import org.reactfx.RigidObservable;
+
+public abstract class RigidVal<T>
+extends RigidObservable<Consumer<? super T>> implements Val<T>
+{
+    
+}

--- a/reactfx/src/main/java/org/reactfx/value/Val.java
+++ b/reactfx/src/main/java/org/reactfx/value/Val.java
@@ -1,18 +1,5 @@
 package org.reactfx.value;
 
-import java.time.Duration;
-import java.util.NoSuchElementException;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
 import javafx.animation.Interpolatable;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.Property;
@@ -21,20 +8,19 @@ import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.stage.Window;
-
-import org.reactfx.Change;
-import org.reactfx.EventStream;
-import org.reactfx.EventStreamBase;
-import org.reactfx.EventStreams;
-import org.reactfx.Observable;
-import org.reactfx.Subscription;
+import org.reactfx.*;
 import org.reactfx.collection.LiveList;
-import org.reactfx.util.HexaFunction;
-import org.reactfx.util.Interpolator;
-import org.reactfx.util.PentaFunction;
-import org.reactfx.util.TetraFunction;
-import org.reactfx.util.TriFunction;
-import org.reactfx.util.WrapperBase;
+import org.reactfx.util.*;
+
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.*;
 
 /**
  * Adds more operations to {@link ObservableValue}.
@@ -773,33 +759,29 @@ extends ObservableValue<T>, Observable<Consumer<? super T>> {
     }
     
     /**
-     * Returns a {@linkplain Val} whose value is {@code placeholder}. Upon the
+     * Returns a {@linkplain Val} whose value is an empty {@linkplain Try}. Upon the
      * first call of {@code getValue()}, {@code callable} will be executed in
      * parallel and the result will become the new value of this
      * {@linkplain Val}. In contrast to {@linkplain Val#lazy(Supplier)}, this
      * will result in listeners being notified.
      * <p>
-     * The {@linkplain Callable} should handle any errors itself. Any
-     * {@linkplain Exception} will be rethrown on the FX Thread.
+     * Any exception thrown by the callable will be caught and returned as part
+     * of the {@linkplain Try}. The execution is handled by
+     * {@linkplain ForkJoinPool#commonPool()}. For more control, see
+     * {@linkplain Val#lazyAsync(Callable, Executor)}.
      */
-    static <T> Val<T> lazyAsync(T placeholder, Callable<T> callable) {
-        // Not sure about Callable, as it specifically allows throwing any
-        // checked exception
+    static <T> Val<Try<T>> lazyAsync(Callable<T> callable) {
         return null;
     }
     
-    static <T> Val<T> lazyAsync(
-            T placeholder,
+    static <T> Val<Try<T>> lazyAsync(
             Callable<T> callable,
             Executor executor) {
         return null;
     }
     
-    static <T> Val<T> lazyAsync(
-            T placeholder,
-            Supplier<CompletionStage<T>> completionStage) {
-        // This might need a different name as Supplier and Callable have the
-        // same signature
+    static <T> Val<Try<T>> awaitAsync(
+            CompletionStage<T> completionStage) {
         return null;
     }
 }

--- a/reactfx/src/main/java/org/reactfx/value/Val.java
+++ b/reactfx/src/main/java/org/reactfx/value/Val.java
@@ -4,6 +4,9 @@ import java.time.Duration;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -744,6 +747,60 @@ extends ObservableValue<T>, Observable<Consumer<? super T>> {
                 .flatMap(node.sceneProperty(), Scene::windowProperty)
                 .flatMap(Window::showingProperty)
                 .orElseConst(false);
+    }
+    
+    /**
+     * Returns a {@linkplain Val} with the value returned by {@code supplier}.
+     * The {@linkplain Supplier} will only be called when {@code getValue()} is
+     * called for the first time. It will not be called again. Although
+     * technically the value is undefined until requested for the first time,
+     * this will not result in a change. No listener will ever be notified.
+     */
+    static <T> Val<T> lazy(Supplier<T> supplier) {
+        return new RigidVal<T>() {
+            Supplier<T> sup = supplier;
+            T value;
+            
+            @Override
+            public T getValue() {
+                if (sup != null) {
+                    value = sup.get();
+                    sup = null;
+                }
+                return value;
+            }
+        };
+    }
+    
+    /**
+     * Returns a {@linkplain Val} whose value is {@code placeholder}. Upon the
+     * first call of {@code getValue()}, {@code callable} will be executed in
+     * parallel and the result will become the new value of this
+     * {@linkplain Val}. In contrast to {@linkplain Val#lazy(Supplier)}, this
+     * will result in listeners being notified.
+     * <p>
+     * The {@linkplain Callable} should handle any errors itself. Any
+     * {@linkplain Exception} will be rethrown on the FX Thread.
+     */
+    static <T> Val<T> lazyAsync(T placeholder, Callable<T> callable) {
+        // Not sure about Callable, as it specifically allows throwing any
+        // checked exception
+        return null;
+    }
+    
+    static <T> Val<T> lazyAsync(
+            T placeholder,
+            Callable<T> callable,
+            Executor executor) {
+        return null;
+    }
+    
+    static <T> Val<T> lazyAsync(
+            T placeholder,
+            Supplier<CompletionStage<T>> completionStage) {
+        // This might need a different name as Supplier and Callable have the
+        // same signature
+        return null;
     }
 }
 

--- a/reactfx/src/test/java/org/reactfx/TicksTest.java
+++ b/reactfx/src/test/java/org/reactfx/TicksTest.java
@@ -16,6 +16,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.reactfx.util.FxTimer;
+import org.reactfx.util.ScheduledExecutorServiceTimer;
 
 
 public class TicksTest {

--- a/reactfx/src/test/java/org/reactfx/value/LazyValTest.java
+++ b/reactfx/src/test/java/org/reactfx/value/LazyValTest.java
@@ -1,0 +1,477 @@
+package org.reactfx.value;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.reactfx.Subscription;
+import org.reactfx.util.Try;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Johannes on 27.06.2016.
+ */
+@RunWith(Enclosed.class)
+public class LazyValTest {
+
+    // FX Preparation
+
+    private static final CountDownLatch latch = new CountDownLatch(1);
+
+    @Ignore
+    public static class AppLauncher extends Application {
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            latch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void startFx() {
+        Thread t = new Thread(() -> Application.launch(AppLauncher.class));
+        t.setDaemon(true);
+        t.start();
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            fail("Interrupted!");
+        }
+    }
+
+    @AfterClass
+    public static void stopFx() {
+        Platform.exit();
+    }
+
+    /**
+     * Runs the task on the FX Thread, but waits until it completes. Any
+     * exception thrown during {@code task.run()} will be rethrown on the test
+     * thread.
+     *
+     * @param task
+     */
+    private static void doOnFx(Runnable task) {
+        if (Platform.isFxApplicationThread()) {
+            try {
+                task.run();
+            } catch (AssertionError e) {
+                throw new RuntimeException(e);
+            }
+        }
+        else {
+            final CountDownLatch latch = new CountDownLatch(1);
+            final AtomicReference<Throwable> excs = new AtomicReference<>();
+            Platform.runLater(() -> {
+                try {
+                    doOnFx(task);
+                }
+                catch(Throwable e) {
+                    excs.set(e);
+                }
+                finally {
+                    latch.countDown();
+                }
+            });
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+            finally {
+                checkFxExceptions(excs.get());
+            }
+        }
+    }
+
+    private static void checkFxExceptions(Throwable e) {
+
+        if (e != null)
+        {
+            if (e.getCause() instanceof AssertionError)
+            {
+                throw (AssertionError) e.getCause();
+            }
+            else {
+                fail("Failed: " + e);
+            }
+        }
+    }
+
+    public static class Lazy {
+
+        @Test
+        public void ensureLaziness() {
+            Val.lazy(() -> {
+                fail("Synchronous method is not lazy.");
+                return new Object();
+            });
+        }
+
+        @Test
+        public void ensureInitializedOnce() {
+            Val<String> val = Val.lazy(new Supplier<String>() {
+                boolean called = false;
+
+                @Override
+                public String get() {
+                    if (called) {
+                        fail("Supplier called twice.");
+                    }
+                    called = true;
+                    return "Hello World!";
+                }
+            });
+
+            assertEquals(
+                    "lazyVal returned wrong value on first call.",
+                    "Hello World!",
+                    val.getValue());
+            assertEquals(
+                    "lazyVal returned wrong value on second call.",
+                    "Hello World!",
+                    val.getValue());
+        }
+
+        @Test
+        public void ensureNotInvalidated() {
+            Val<String> val = Val.lazy(() -> "Hello World!");
+
+            val.observe(it -> fail("lazyVal is invalidated."));
+
+            assertEquals(
+                    "lazyVal returned wrong value.",
+                    "Hello World!",
+                    val.getValue());
+        }
+    }
+
+    public static class LazyAsync {
+
+        @Test(timeout = 1000L)
+        public void ensureLaziness() {
+            final Val<Try<String>> val = Val.lazyAsync(() -> {
+                fail("Synchronous method is not lazy.");
+                return "Failed!";
+            });
+
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            assertTrue("Val is not empty.", val.isEmpty());
+        }
+
+        @Test(timeout = 2000L)
+        public void ensureInitializedOnce() {
+            // Create Val on FX thread
+            AtomicReference<Val<Try<String>>> val = new AtomicReference<>();
+            doOnFx(() -> val.set(Val.lazyAsync(new Callable<String>() {
+                boolean called = false;
+
+                @Override
+                public String call() throws Exception {
+                    if (called) {
+                        fail("Supplier called twice.");
+                    }
+                    called = true;
+                    Thread.sleep(200L);
+                    return "Hello World!";
+                }
+            })));
+
+            doOnFx(() -> assertTrue(
+                    "New Val is not empty.",
+                    val.get().isEmpty()));
+
+            // Add two listeners on FX thread to try and force
+            // double initialization
+            final CountDownLatch observed = new CountDownLatch(2);
+
+            AtomicReference<Subscription> subs = new AtomicReference<>();
+            doOnFx(() -> {
+                subs.set(val.get().observeChanges((obs, oldVal, newVal) -> {
+                    doOnFx(() -> {
+                        assertTrue(
+                                "Old value after initialization was not null.",
+                                oldVal == null);
+                        assertTrue(
+                                "Initialization was not a success.",
+                                newVal.isSuccess());
+                        assertEquals(
+                                "New value after initialization is not correct.",
+                                "Hello World!",
+                                newVal.get());
+                    });
+                    observed.countDown();
+                }));
+
+                subs.set(subs.get().and(val.get().observeChanges(
+                        (obs, oldVal, newVal) -> {
+                            doOnFx(() -> {
+                                assertTrue(
+                                        "Old value after initialization was not null.",
+                                        oldVal == null);
+                                assertTrue(
+                                        "Initialization was not a success.",
+                                        newVal.isSuccess());
+                                assertEquals(
+                                        "New value after initialization is not correct.",
+                                        "Hello World!",
+                                        newVal.get());
+                            });
+                            observed.countDown();
+                })));
+            });
+
+            // Initialization runs on background, so it should still be empty
+            doOnFx(() -> assertTrue(
+                    "New Val is not empty.",
+                    val.get().isEmpty()));
+
+            try {
+                observed.await();
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            // unsubscribe and subscribe again to try and force reinitialization
+            doOnFx(() -> {
+                subs.get().unsubscribe();
+                val.get().observe(
+                        it -> fail("Invalidated after initialization!"));
+            });
+
+            // wait a bit to make sure
+            try {
+                Thread.sleep(500L);
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            // check final values
+            doOnFx(() -> {
+                assertTrue("Val is not initialized.", val.get().isPresent());
+                assertEquals(
+                        "Final value is not correct.",
+                        "Hello World!",
+                        val.get().getValue().get());
+            });
+        }
+
+        @Test(timeout = 1500L)
+        public void ensureExceptionsGetCaught() {
+            // Create Val on FX thread
+            AtomicReference<Val<Try<String>>> val = new AtomicReference<>();
+            doOnFx(() -> val.set(Val.lazyAsync(() -> {
+                throw new IllegalStateException("Success!");
+            })));
+
+            final CountDownLatch observed = new CountDownLatch(1);
+
+            // Add observer on FX thread
+            doOnFx(() -> val.get().observeChanges((obs, oldVal, newVal) -> {
+                doOnFx(() -> {
+                    assertTrue(
+                            "Old value after initialization was not null.",
+                            oldVal == null);
+                    assertTrue(
+                            "Initialization was not a failure.",
+                            newVal.isFailure());
+                    assertTrue(
+                            "Did not receive the expected Exception.",
+                            newVal.getFailure() instanceof IllegalStateException);
+                });
+                observed.countDown();
+            }));
+
+            try {
+                observed.await();
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            // assert final error
+            doOnFx(() -> {
+                assertTrue("Val is not initialized.", val.get().isPresent());
+                assertTrue(
+                        "Final value is not a failure.",
+                        val.get().getValue().isFailure());
+            });
+        }
+    }
+
+
+    public static class AwaitAsync {
+        @Test(timeout = 1000L)
+        public void ensureInitiallyEmpty() {
+            final Val<Try<String>> val = Val.awaitAsync(
+                    CompletableFuture.supplyAsync(() -> {
+                        try {
+                            Thread.sleep(200L);
+                        } catch (InterruptedException e) {
+                            fail("Interrupted!");
+                        }
+                        fail("Synchronous method is not lazy.");
+                        return "Fail";
+                    }));
+
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            assertTrue("Val is not empty.", val.isEmpty());
+        }
+
+        @Test(timeout = 2000L)
+        public void ensureInitialization() {
+            // Create Val on FX thread
+            AtomicReference<Val<Try<String>>> val = new AtomicReference<>();
+            doOnFx(() -> val.set(Val.awaitAsync(
+                    CompletableFuture.supplyAsync(() -> {
+                        try {
+                            Thread.sleep(500L);
+                        } catch (InterruptedException e) {
+                            fail("Interrupted");
+                        }
+                        return "Hello World!";
+            }))));
+
+            doOnFx(() -> assertTrue(
+                    "New Val is not empty.",
+                    val.get().isEmpty()));
+
+            // Add a listener on FX thread while the initialization is
+            // still running
+            final CountDownLatch observed = new CountDownLatch(1);
+
+            AtomicReference<Subscription> subs = new AtomicReference<>();
+            doOnFx(() -> {
+                subs.set(val.get().observeChanges((obs, oldVal, newVal) -> {
+                    doOnFx(() -> {
+                        assertTrue(
+                                "Old value after initialization was not null.",
+                                oldVal == null);
+                        assertTrue(
+                                "Initialization was not a success.",
+                                newVal.isSuccess());
+                        assertEquals(
+                                "New value after initialization is not correct.",
+                                "Hello World!",
+                                newVal.get());
+                    });
+                    observed.countDown();
+                }));
+            });
+
+            // Initialization runs on background, so it should still be empty
+            doOnFx(() -> assertTrue(
+                    "New Val is not empty.",
+                    val.get().isEmpty()));
+            try {
+                observed.await();
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            // check final values
+            doOnFx(() -> {
+                assertTrue("Val is not initialized.", val.get().isPresent());
+                assertEquals(
+                        "Final value is not correct.",
+                        "Hello World!",
+                        val.get().getValue().get());
+            });
+        }
+
+        @Test(timeout = 2000L)
+        public void ensureExceptionsGetCaught() {
+            // Create Val on FX thread
+            AtomicReference<Val<Try<String>>> val = new AtomicReference<>();
+            doOnFx(() -> val.set(Val.awaitAsync(
+                    CompletableFuture.supplyAsync(() -> {
+                        try {
+                            Thread.sleep(1000L);
+                        } catch (InterruptedException e) {
+                            fail("Interrupted!");
+                        }
+                        throw new IllegalStateException("Success!");
+            }))));
+
+            final CountDownLatch observed = new CountDownLatch(1);
+
+            // Add observer on FX thread
+            doOnFx(() -> val.get().observeChanges((obs, oldVal, newVal) -> {
+                doOnFx(() -> {
+                    assertTrue(
+                            "Old value after initialization was not null.",
+                            oldVal == null);
+                    assertTrue(
+                            "Initialization was not a failure.",
+                            newVal.isFailure());
+                    assertEquals(
+                            "Did not receive the expected Exception.",
+                            IllegalStateException.class,
+                            newVal.getFailure().getCause().getClass());
+                });
+                observed.countDown();
+            }));
+
+            try {
+                observed.await();
+            } catch (InterruptedException e) {
+                fail("Interrupted!");
+            }
+
+            // assert final error
+            doOnFx(() -> {
+                assertTrue("Val is not initialized.", val.get().isPresent());
+                assertTrue(
+                        "Final value is not a failure.",
+                        val.get().getValue().isFailure());
+                assertEquals(
+                        "Caught the wrong exception.",
+                        "Success!",
+                        val.get().getValue().getFailure().getCause().getMessage());
+            });
+        }
+
+        @Test(timeout = 1500L)
+        public void ensureCompletedStageGetsPickedUp() {
+            final CompletableFuture<String> future = new CompletableFuture<>();
+            future.complete("Success!");
+
+            // Create Val on FX thread
+            AtomicReference<Val<Try<String>>> val = new AtomicReference<>();
+            doOnFx(() -> val.set(Val.awaitAsync(future)));
+
+            // Add observer on FX thread
+            doOnFx(() -> val.get().observeChanges((obs, oldVal, newVal) ->
+                    fail("Reported change although CompletableFuture was already completed.")));
+
+            // check final values
+            doOnFx(() -> {
+                assertTrue("Val is not initialized.", val.get().isPresent());
+                assertEquals(
+                        "Final value is not correct.",
+                        "Success!",
+                        val.get().getValue().get());
+            });
+        }
+    }
+}


### PR DESCRIPTION
See [Issue 57](https://github.com/TomasMikula/ReactFX/issues/57)

An implementation and documentation for Val.lazy() is provided. It calls the
given Supplier only once without notifing any observers. It is null-safe, but
not thread-safe.

An API is suggested for Val.lazyAsync(). Three variants are given. One merely
gives a Callable to be executed in some other thread. Another gives the
Executor to be used. Finally, a Supplier for a CompletionStage can be used as
well. Together, these should provide for every case from maximum usability to
maximum control.
