### PR TITLE
Stream documentation and convenience methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gradle.properties
 .classpath
 .project
 .settings/
+.idea/

--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -567,6 +567,28 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
     }
 
     /**
+     * Inversion of {@link #emitBothOnEach(EventStream)}.
+     * For example,
+     * <pre>
+     *     {@code
+     *     EventStream<?> A = ...;
+     *     EventStream<?> B = ...;
+     *     EventStream<?> C = A.combineWithLatestFrom(B);}
+     * </pre>
+     * <p>Returns C. When A emits an event, C emits A and B's most recent events.
+     * Only emits an event when both A and B have emitted at least one new event.
+     * <pre>
+     *     Time ---&gt;
+     *     A :----1-----------2-----3---------4-------&gt;
+     *     B :-a-------b---c-------------d------------&gt;
+     *     C :---[1,a]------[2,c]-[3,c]-----[4,d]-----&gt;
+     * </pre>
+     */
+    default <I> EventStream<Tuple2<T, I>> combineWithLatestFrom(EventStream<I> other) {
+        return new EmitBothOnEachStream<>(other, this).map(tu -> t(tu._2, tu._1));
+    }
+
+    /**
      * Returns a new event stream that emits all the events emitted from this
      * stream and in addition to that re-emits the most recent event on every
      * event emitted from {@code impulse}.

--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -676,6 +676,14 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
     }
 
     /**
+     * @deprecated renamed to {@linkplain EventStream#retainingLast()} to avoid confusion
+     */
+    @Deprecated
+    default SuspendableEventStream<T> forgetful() {
+        return new ForgetfulEventStream<>(this);
+    }
+
+    /**
      * Returns a suspendable event stream that, when suspended, forgets all but
      * the latest event emitted by this event stream. The remembered event, if
      * any, is emitted from the returned stream upon resume.
@@ -683,7 +691,7 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
      * <pre>
      *     {@code
      *     EventStream<?> A = ...;
-     *     EventStream<?> B = A.forgetful();
+     *     EventStream<?> B = A.retainingLast();
      *     }
      * </pre>
      * <p>Returns B. When B is not suspended and A emits an event, B emits that event.
@@ -695,15 +703,15 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
      *     B :-a--b--|---Suspended----|e------f-------&gt;
      * </pre>
      */
-    default SuspendableEventStream<T> forgetful() {
+    default SuspendableEventStream<T> retainingLast() {
         return new ForgetfulEventStream<>(this);
     }
 
     /**
-     * Shortcut for {@code forgetful().suspendedWhen(condition)}.
+     * Shortcut for {@code retainingLast().suspendedWhen(condition)}.
      */
     default EventStream<T> retainLatestWhen(ObservableValue<Boolean> condition) {
-        return forgetful().suspendedWhen(condition);
+        return retainingLast().suspendedWhen(condition);
     }
 
     /**
@@ -740,7 +748,7 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
      *     <li>d = 5 [reduction(5, 7) == 5]</li>
      * </ul>
      *
-     * <p>Note that {@link #forgetful()} is equivalent to
+     * <p>Note that {@link #retainingLast()} is equivalent to
      * {@code reducible((a, b) -> b)}.
      */
     default SuspendableEventStream<T> reducible(BinaryOperator<T> reduction) {

--- a/reactfx/src/main/java/org/reactfx/EventStream.java
+++ b/reactfx/src/main/java/org/reactfx/EventStream.java
@@ -687,12 +687,12 @@ public interface EventStream<T> extends Observable<Consumer<? super T>> {
      *     }
      * </pre>
      * <p>Returns B. When B is not suspended and A emits an event, B emits that event.
-     * When B is suspended and A emits an event, B does not emit that event, nor does
-     * it store that event for later emission. Those events are "forgotten."
+     * When B is suspended and A emits an event, B does not emit that event, but
+     * stores the latest. It is emitted upon resume.
      * <pre>
      *     Time ---&gt;
      *     A :-a--b----c---d-----e------------f-------&gt;
-     *     B :-a--b--|---Suspended----|-------f-------&gt;
+     *     B :-a--b--|---Suspended----|e------f-------&gt;
      * </pre>
      */
     default SuspendableEventStream<T> forgetful() {

--- a/reactfx/src/test/java/org/reactfx/ForgetfulEventStreamTest.java
+++ b/reactfx/src/test/java/org/reactfx/ForgetfulEventStreamTest.java
@@ -13,7 +13,7 @@ public class ForgetfulEventStreamTest {
     @Test
     public void test() {
         EventSource<Integer> source = new EventSource<>();
-        SuspendableEventStream<Integer> suspendable = source.forgetful();
+        SuspendableEventStream<Integer> suspendable = source.retainingLast();
         List<Integer> emitted = new ArrayList<>();
         suspendable.subscribe(emitted::add);
 
@@ -30,7 +30,7 @@ public class ForgetfulEventStreamTest {
     @Test
     public void testResetOnUnsubscribe() {
         EventSource<Integer> source = new EventSource<>();
-        SuspendableEventStream<Integer> suspendable = source.forgetful();
+        SuspendableEventStream<Integer> suspendable = source.retainingLast();
         List<Integer> emitted = new ArrayList<>();
         Subscription sub = suspendable.subscribe(emitted::add);
 


### PR DESCRIPTION
After some work with the `EventStream`s, there are two thinks I have found rather annoying.

One is the `EventStream.emitBothOnEach(EventStream)` method. I have been using the streams to publish state changes to GUI elements. Often, a new state for part A needs to be treated slightly different depending on the state of part B. This can be solved with the given method, but the order is inverted:

```
streamB.emitBothOnEach(streamA).subscribe(...);
```

To handle events for A, I have to write the other stream first. I have added another method, which internally just swaps the arguments.

```
streamA.combineWithLatestFrom(streamB).subscribe(...);
```

This is much more idiomatic to the problem at hand.

The other inconvenience is a mistake in the documentation for `EventStream.forgetful()`, combined with the rather confusing name. I have corrected the documentation. Also I propose to rename the method to `retainingLast()`, which describes better what it does and fits with `retainLatestWhen(EventStream)`.
